### PR TITLE
feat(ci): test on Node.js v16, remove Node.js v10 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [12, 14, 16]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,12 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 12
+          node-version: 14
       - name: Update npm
         run: |
           npm install -g npm
           npm --version
       - uses: actions/checkout@v2.3.4
-
       - name: Install dependencies
         uses: bahmutov/npm-install@v1.7.4
         with:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "10 || 12 || >=14"
+    "node": "12 || 14 || >=16"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported. Node.js v12 is now
the minimum supported version.