### PR TITLE
Fix custom registry with trailing slash

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -78,10 +78,15 @@ module.exports = {
             }
         }
 
+        let registry = args.registry.slice(args.registry.search(/\:\/\//) + 1);
+
+        // Trim trailing slash before a new one is added later.
+        if (registry.endsWith('/')) {
+            registry = registry.slice(0, -1);
+        }
+
         var authWrite = lines.findIndex(function (element, index, array) {
-            const obtainedRegistry = args.registry.slice(args.registry.search(/\:\/\//, '') + 1)
-            const updatedRegistry = obtainedRegistry.endsWith('/') ? obtainedRegistry.slice(0, -1) : obtainedRegistry;
-            if ( element.indexOf(updatedRegistry + '/:_authToken=') !== -1) {
+            if (element.includes(`${registry}/:_authToken=`)) {
                 // If an entry for the auth token is found, replace it
                 array[index] = element.replace(/authToken\=.*/, 'authToken=' + (args.quotes ? '"' : '') +
                 response.token + (args.quotes ? '"' : ''));
@@ -91,9 +96,7 @@ module.exports = {
 
         // If no entry for the auth token is found, add one
         if (authWrite === -1) {
-            const obtainedRegistry = args.registry.slice(args.registry.search(/\:\/\//, '') + 1)
-            const updatedRegistry = obtainedRegistry.endsWith('/') ? obtainedRegistry.slice(0, -1) : obtainedRegistry;
-            lines.push(updatedRegistry + '/:_authToken=' + (args.quotes ? '"' : '') + response.token + (args.quotes ? '"' : ''));
+            lines.push(registry + '/:_authToken=' + (args.quotes ? '"' : '') + response.token + (args.quotes ? '"' : ''));
         }
 
         var toWrite = lines.filter(function (element) {

--- a/lib/login.js
+++ b/lib/login.js
@@ -79,8 +79,9 @@ module.exports = {
         }
 
         var authWrite = lines.findIndex(function (element, index, array) {
-            if ( element.indexOf(args.registry.slice(args.registry.search(/\:\/\//, '') + 1) +
-            '/:_authToken=') !== -1) {
+            const obtainedRegistry = args.registry.slice(args.registry.search(/\:\/\//, '') + 1)
+            const updatedRegistry = obtainedRegistry.endsWith('/') ? obtainedRegistry.slice(0, -1) : obtainedRegistry;
+            if ( element.indexOf(updatedRegistry + '/:_authToken=') !== -1) {
                 // If an entry for the auth token is found, replace it
                 array[index] = element.replace(/authToken\=.*/, 'authToken=' + (args.quotes ? '"' : '') +
                 response.token + (args.quotes ? '"' : ''));
@@ -90,8 +91,9 @@ module.exports = {
 
         // If no entry for the auth token is found, add one
         if (authWrite === -1) {
-            lines.push(args.registry.slice(args.registry.search(/\:\/\//, '') +
-            1) + '/:_authToken=' + (args.quotes ? '"' : '') + response.token + (args.quotes ? '"' : ''));
+            const obtainedRegistry = args.registry.slice(args.registry.search(/\:\/\//, '') + 1)
+            const updatedRegistry = obtainedRegistry.endsWith('/') ? obtainedRegistry.slice(0, -1) : obtainedRegistry;
+            lines.push(updatedRegistry + '/:_authToken=' + (args.quotes ? '"' : '') + response.token + (args.quotes ? '"' : ''));
         }
 
         var toWrite = lines.filter(function (element) {

--- a/tests/internal.spec.js
+++ b/tests/internal.spec.js
@@ -18,6 +18,8 @@ var testData = {
   }
 }
 
+var testDataRegistryWithTrailingSlash = 'https://artifactory.company.com/artifactory/api/npm/npm-registry/';
+
 describe('Can handle', function () {
   it('missing username', function () {
     expect(nclWrapper).to.throw();
@@ -60,6 +62,11 @@ describe('Can resolve', function () {
   it('custom registry', function () {
     var args = ncl.processArguments(testData.username, testData.password, testData.email, testData.registry);
     expect(args).to.have.property('registry', testData.registry);
+  });
+
+  it('custom registry with trailing slash', function () {
+    var args = ncl.processArguments(testData.username, testData.password, testData.email, testDataRegistryWithTrailingSlash);
+    expect(args).to.have.property("registry", testDataRegistryWithTrailingSlash);
   });
 
   it('default scope', function () {
@@ -117,12 +124,27 @@ describe('Can generate', function () {
     expect(toWrite).to.include('//npm.random.com/:_authToken=' + testData.response.token);
   });
 
+  it('file with custom registry (with trailing slash) but no scope', function () {
+    var args = ncl.processArguments(testData.username, testData.password, testData.email, testDataRegistryWithTrailingSlash);
+    var toWrite = ncl.generateFileContents(args, '', testData.response);
+    expect(toWrite).to.have.length(1)
+    expect(toWrite).to.include('//artifactory.company.com/artifactory/api/npm/npm-registry/:_authToken=' + testData.response.token);
+  });
+
   it('file with custom registry and custom scope', function () {
     var args = ncl.processArguments(testData.username, testData.password, testData.email, testData.registry, testData.scope);
     var toWrite = ncl.generateFileContents(args, '', testData.response);
     expect(toWrite).to.have.length(2)
     expect(toWrite).to.include('//npm.random.com/:_authToken=' + testData.response.token);
     expect(toWrite).to.include(testData.scope + ':registry=' + testData.registry);
+  });
+
+  it('file with custom registry (with trailing slash) and custom scope', function () {
+    var args = ncl.processArguments(testData.username, testData.password, testData.email, testDataRegistryWithTrailingSlash, testData.scope);
+    var toWrite = ncl.generateFileContents(args, '', testData.response);
+    expect(toWrite).to.have.length(2)
+    expect(toWrite).to.include('//artifactory.company.com/artifactory/api/npm/npm-registry/:_authToken=' + testData.response.token);
+    expect(toWrite).to.include(testData.scope + ':registry=' + testDataRegistryWithTrailingSlash);
   });
 });
 


### PR DESCRIPTION
Fixes an issue when using a trailing slash on the given custom registry to avoid double `/`

Related to:
https://github.com/postmanlabs/npm-cli-login/issues/20
https://github.com/postmanlabs/npm-cli-login/issues/75