### PR TITLE
Fix token de-structuring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = function (user, pass, email, registry, scope, quotes, configPat
         throw new TypeError('`email` is a required argument.')
     }
 
-    ncl.login(finalArgs, function (err, { token }) {
+    ncl.login(finalArgs, function (err, data) {
         if (err) {
             throw err;
         }
@@ -30,6 +30,7 @@ module.exports = function (user, pass, email, registry, scope, quotes, configPat
                 throw err;
             }
             else {
+                const { token } = data;
                 const newContent = ncl.generateFileContents(
                     finalArgs,
                     content,


### PR DESCRIPTION
When `loginCouch` fails, the callback fn is called with [only one param](https://github.com/kenany/npm-cli-login/blob/main/lib/login.js#L40) (`err`), so the second argument de-structuring fails.

An error would look like:

```
/root/.npm/_npx/3dd36092268e68d0/node_modules/@kenan/npm-cli-login/lib/index.js:24
    ncl.login(finalArgs, function (err, { token }) {
                                          ^

TypeError: Cannot destructure property 'token' of 'undefined' as it is undefined.
    at /root/.npm/_npx/3dd36092268e68d0/node_modules/@kenan/npm-cli-login/lib/index.js:24:43
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```