### PR TITLE
feat: drop Node.js v18 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,11 +2,11 @@ name: nodejs
 on: [pull_request, push]
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [18, 20]
-        os: [ubuntu-latest]
+        node-version: [20, 22, 24]
     steps:
     - name: Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v5.0.0
         with:
-          node-version: 22.19.0
+          node-version: 24.7.0
       - name: Update npm
         run: |
           npm install -g npm

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "provenance": true
   },
   "engines": {
-    "node": "18 || >=20"
+    "node": "20 || 22 || >=24"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
BREAKING CHANGE: Node.js v18 is no longer supported.